### PR TITLE
Implement simple RBAC with whitelist

### DIFF
--- a/src/RESTObjects/RESTAPI_SecurityObjects.h
+++ b/src/RESTObjects/RESTAPI_SecurityObjects.h
@@ -11,12 +11,15 @@
 #include "Poco/Data/LOB.h"
 #include "Poco/Data/LOBStream.h"
 #include "Poco/JSON/Object.h"
+#include "Poco/Net/HTTPRequest.h"
 #include "framework/OpenWifiTypes.h"
 #include "framework/utils.h"
 #include <string>
 #include <type_traits>
 #include <iostream>
 #include <fstream>
+#include <map>
+#include <set>
 
 namespace OpenWifi {
 	uint64_t Now();
@@ -55,6 +58,10 @@ namespace OpenWifi {
 
 			void to_json(Poco::JSON::Object &Obj) const;
 			bool from_json(const Poco::JSON::Object::Ptr &Obj);
+		};
+
+		const std::map<std::string, std::set<std::string>> API_WHITELIST = {
+			{"/api/v1/device", {Poco::Net::HTTPRequest::HTTP_POST, Poco::Net::HTTPRequest::HTTP_PUT, Poco::Net::HTTPRequest::HTTP_DELETE}}
 		};
 
 		enum USER_ROLE {


### PR DESCRIPTION
**Description:**
Non-admin/root users should not be able to make PUT, POST, or DELETE API calls to any endpoint unless that endpoint and the corresponding method are in the whitelist.
Note: this is not meant to be upstreamed.

**Trello link:**
https://trello.com/c/5wsAYyrW/437-owgw-simple-rbac-with-whitelist

**Summary of Changes:**
- RoleIsAuthorized function implemented to perform role and whitelist check - this function was previously unused (always returned true) so this seemed like the correct place to put RBAC logic
- static whitelist created to map allowed API endpoints and HTTP verbs.
