### PR TITLE
includeProvisioned flag is now checked for countOnly.

### DIFF
--- a/src/RESTAPI/RESTAPI_devices_handler.cpp
+++ b/src/RESTAPI/RESTAPI_devices_handler.cpp
@@ -127,7 +127,7 @@ namespace OpenWifi {
 
 		} else if (QB_.CountOnly) {
 			uint64_t Count = 0;
-			if (StorageService()->GetDeviceCount(Count, platform)) {
+			if (StorageService()->GetDeviceCount(Count, platform, includeProvisioned)) {
 				return ReturnCountOnly(Count);
 			}
 		} else if (serialOnly) {

--- a/src/StorageService.h
+++ b/src/StorageService.h
@@ -161,7 +161,7 @@ namespace OpenWifi {
 		bool UpdateDevice(Poco::Data::Session &Sess, GWObjects::Device &NewDeviceDetails);
 		bool DeviceExists(std::string &SerialNumber);
 		bool SetConnectInfo(std::string &SerialNumber, std::string &Firmware);
-		bool GetDeviceCount(uint64_t &Count, const std::string &platform = "");
+		bool GetDeviceCount(uint64_t &Count, const std::string &platform = "", bool includeProvisioned = true);
 		bool GetDeviceSerialNumbers(uint64_t From, uint64_t HowMany,
 									std::vector<std::string> &SerialNumbers,
 									const std::string &orderBy = "",


### PR DESCRIPTION
**Description:**
includeProvisioned flag is now checked for countOnly.

**Trello link:**
https://trello.com/c/SXWSV8xD/471-fix-devices-api-needs-countonly-to-work-with-includeprovisioned

**Summary of Changes:**
- includeProvisioned flag is now checked for countOnly.

