### PR TITLE
fix: uptime update after reboot

### DIFF
--- a/src/RESTObjects/RESTAPI_GWobjects.cpp
+++ b/src/RESTObjects/RESTAPI_GWobjects.cpp
@@ -295,7 +295,7 @@ namespace OpenWifi::GWObjects {
 		field_to_json(Obj, "started", started);
 		field_to_json(Obj, "sessionId", sessionId);
 		field_to_json(Obj, "connectionCompletionTime", connectionCompletionTime);
-		field_to_json(Obj, "totalConnectionTime", Utils::Now() - started);
+		field_to_json(Obj, "totalConnectionTime", started ? Utils::Now() - started : 0);
 		field_to_json(Obj, "certificateExpiryDate", certificateExpiryDate);
 		field_to_json(Obj, "connectReason", connectReason);
 		field_to_json(Obj, "uptime", uptime);


### PR DESCRIPTION
# Description

Uptime is incorrectly updated while AP is in reboot or firmware upgrade state (or disconnected).

More details in:
https://trello.com/c/a2lJy3rM`

# Summary of changes:
- Fixed incorrect total connection time when `started = 0`