### PR TITLE
commands API will return 400 if command fails on device.

### DIFF
--- a/src/framework/RESTAPI_Handler.h
+++ b/src/framework/RESTAPI_Handler.h
@@ -595,8 +595,8 @@ namespace OpenWifi {
 
 		inline bool IsAuthorized(bool &Expired, bool &Contacted, bool SubOnly = false);
 
-		inline void ReturnObject(Poco::JSON::Object &Object) {
-			PrepareResponse();
+		inline void ReturnObject(Poco::JSON::Object &Object, Poco::Net::HTTPResponse::HTTPStatus Status = Poco::Net::HTTPResponse::HTTP_OK) {
+			PrepareResponse(Status);
 			if (Request != nullptr) {
 				//   can we compress ???
 				auto AcceptedEncoding = Request->find("Accept-Encoding");


### PR DESCRIPTION
**Description:**
Command failure on device causes API to return 400 instead of 200

**Trello link:**
https://trello.com/c/zra6sAit/520-owgw-commands-api-should-not-return-200-if-command-fails-on-device

**Summary of Changes:**
- When Cmd.ErrorCode is non-zero (zero means success on device) return early into SetCommandStatus
- Update Handler->ReturnObject to take an optional HTTP status code to return (defaults to 200 so no other uses of this method are changed)
- When Cmd.ErrorCode is non-zero SetCommandStatus will return 400 status code along with the full request body that would have been returned previously with the 200 status code.
