### PR TITLE
OLS-246: feat: add cable diagnostics command

### DIFF
--- a/src/RESTAPI/RESTAPI_device_commandHandler.h
+++ b/src/RESTAPI/RESTAPI_device_commandHandler.h
@@ -72,6 +72,8 @@ namespace OpenWifi {
 					  const GWObjects::DeviceRestrictions &R);
 		void FixedConfig(const std::string &UUID, uint64_t RPC, std::chrono::milliseconds timeout,
 					  const GWObjects::DeviceRestrictions &R);
+		void CableDiagnostics(const std::string &UUID, uint64_t RPC, std::chrono::milliseconds timeout,
+					  const GWObjects::DeviceRestrictions &R);
 
 		static auto PathName() {
 			return std::list<std::string>{"/api/v1/device/{serialNumber}/{command}"};

--- a/src/RESTObjects/RESTAPI_GWobjects.cpp
+++ b/src/RESTObjects/RESTAPI_GWobjects.cpp
@@ -808,4 +808,15 @@ namespace OpenWifi::GWObjects {
 		}
 		return false;
 	}
+
+	bool CableDiagnostics::from_json(const Poco::JSON::Object::Ptr &Obj) {
+		try {
+			field_from_json(Obj, "serial", serialNumber);
+			field_from_json(Obj, "when", when);
+			field_from_json(Obj, "ports", ports);
+			return true;
+		} catch (const Poco::Exception &E) {
+		}
+		return false;
+	}
 } // namespace OpenWifi::GWObjects

--- a/src/RESTObjects/RESTAPI_GWobjects.h
+++ b/src/RESTObjects/RESTAPI_GWobjects.h
@@ -540,4 +540,11 @@ namespace OpenWifi::GWObjects {
 
 		bool from_json(const Poco::JSON::Object::Ptr &Obj);
 	};
+	struct CableDiagnostics {
+		std::string 	serialNumber;
+		std::uint64_t 	when;
+		std::vector<std::string> ports;
+
+		bool from_json(const Poco::JSON::Object::Ptr &Obj);
+	};
 } // namespace OpenWifi::GWObjects

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -582,6 +582,7 @@ namespace OpenWifi::RESTAPI::Protocol {
 	static const char *BANDWIDTH = "bandwidth";
 
 	static const char *FIXEDCONFIG = "fixedconfig";
+	static const char *CABLEDIAGNOSTICS = "cablediagnostics";
 } // namespace OpenWifi::RESTAPI::Protocol
 
 namespace OpenWifi::uCentralProtocol {
@@ -695,6 +696,7 @@ namespace OpenWifi::uCentralProtocol {
 	static const char *ACTIONS = "actions";
 
 	static const char *FIXEDCONFIG = "fixedconfig";
+	static const char *CABLEDIAGNOSTICS = "cablediagnostics";
 
 } // namespace OpenWifi::uCentralProtocol
 
@@ -793,6 +795,7 @@ namespace OpenWifi::APCommands {
 		transfer,
 		powercycle,
 		fixedconfig,
+		cablediagnostics,
 		unknown
 	};
 
@@ -808,7 +811,7 @@ namespace OpenWifi::APCommands {
 		RESTAPI::Protocol::PING,		 RESTAPI::Protocol::SCRIPT,
 		RESTAPI::Protocol::RRM,		 	 RESTAPI::Protocol::CERTUPDATE,
 		RESTAPI::Protocol::TRANSFER,	 RESTAPI::Protocol::POWERCYCLE,
-		RESTAPI::Protocol::FIXEDCONFIG
+		RESTAPI::Protocol::FIXEDCONFIG,  RESTAPI::Protocol::CABLEDIAGNOSTICS
 	};
 
 	inline const char *to_string(Commands Cmd) { return uCentralAPCommands[(uint8_t)Cmd]; }


### PR DESCRIPTION
# Description
Switch requires cable diagnostics command.
Details are in: https://telecominfraproject.atlassian.net/browse/OLS-246

# Summary of changes
- Added cable diagnostics command.

NOTE: Using AP Commands framework to implement this command. In future switch commands might be separated from AP commands.