### PR TITLE
WIFI-14229: feat: compressed config

### DIFF
--- a/src/RESTAPI/RESTAPI_RPC.cpp
+++ b/src/RESTAPI/RESTAPI_RPC.cpp
@@ -54,8 +54,8 @@ namespace OpenWifi::RESTAPI_RPC {
 						std::chrono::milliseconds WaitTimeInMs, Poco::JSON::Object *ObjectToReturn,
 						RESTAPIHandler *Handler, Poco::Logger &Logger, bool Deferred) {
 
-		Logger.information(fmt::format("{},{}: New {} command. User={} Serial={}. ", Cmd.UUID,
-									   RPCID, Cmd.Command, Cmd.SubmittedBy, Cmd.SerialNumber));
+		Logger.information(fmt::format("{},{}: New {} command. User={} Serial={} Details={}. ", Cmd.UUID,
+									   RPCID, Cmd.Command, Cmd.SubmittedBy, Cmd.SerialNumber, Cmd.Details));
 		Cmd.Submitted = Utils::Now();
 		Cmd.Executed = 0;
 

--- a/src/RESTAPI/RESTAPI_device_commandHandler.cpp
+++ b/src/RESTAPI/RESTAPI_device_commandHandler.cpp
@@ -694,9 +694,32 @@ namespace OpenWifi {
 				Params.stringify(ParamStream);
 				Cmd.Details = ParamStream.str();
 
+				// retrieve capabilities and encode/compress parameters, if required
+				Poco::JSON::Object ConfigParams = Params;
+				GWObjects::Capabilities Caps;
+				if (StorageService()->GetDeviceCapabilities(SerialNumber_, Caps)) {
+					Poco::JSON::Object CapsJson;
+					Caps.to_json(CapsJson);
+					auto DeviceCaps = CapsJson.getObject(uCentralProtocol::CAPABILITIES);
+					if (DeviceCaps->has("compress_cmd") && DeviceCaps->get("compress_cmd")) {
+						// compressed command capability present and it is set, compress parameters
+						Poco::JSON::Object CompressedParams;
+						std::string CompressedBase64Data;
+						std::uint64_t UncompressedDataLen = ParamStream.str().length();
+						if (Utils::CompressAndEncodeBase64(ParamStream.str(), CompressedBase64Data)) {
+							// set compressed, base 64 encoded data and length of uncompressed data
+							CompressedParams.set(uCentralProtocol::COMPRESS_64, CompressedBase64Data);
+							CompressedParams.set(uCentralProtocol::COMPRESS_SZ, UncompressedDataLen);
+							ConfigParams = CompressedParams;
+							Cmd.Details.append(" (compressed: " + CompressedBase64Data + ")");
+						}
+					}
+				}
+
+
 				// AP_WS_Server()->SetPendingUUID(SerialNumber_, NewUUID);
 				RESTAPI_RPC::WaitForCommand(CMD_RPC, APCommands::Commands::configure, true,
-												   Cmd, Params, *Request, *Response, timeout,
+												   Cmd, ConfigParams, *Request, *Response, timeout,
 												   nullptr, this, Logger_);
 
 				if(!Cmd.Executed) {

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -611,6 +611,7 @@ namespace OpenWifi::uCentralProtocol {
 	static const char *CFGPENDING = "cfgpending";
 	static const char *RECOVERY = "recovery";
 	static const char *COMPRESS_64 = "compress_64";
+	static const char *COMPRESS_SZ = "compress_sz";
 	static const char *CAPABILITIES = "capabilities";
 	static const char *REQUEST_UUID = "request_uuid";
 	static const char *SANITY = "sanity";

--- a/src/framework/utils.cpp
+++ b/src/framework/utils.cpp
@@ -590,6 +590,26 @@ namespace OpenWifi::Utils {
 		return false;
 	}
 
+	//
+	// Compress given data using utility function and encode it in base64 format.
+	//
+	bool CompressAndEncodeBase64(const std::string& UnCompressedData, std::string& CompressedBase64Data) {
+
+		unsigned long CompressedDataSize = UnCompressedData.size();
+		std::vector<Bytef> CompressedData(CompressedDataSize);
+		auto status = compress(&CompressedData[0], &CompressedDataSize,
+								(Bytef*) UnCompressedData.c_str(), UnCompressedData.size());
+		if (status == Z_OK) {
+			CompressedBase64Data = OpenWifi::Utils::base64encode(&CompressedData[0], CompressedDataSize);
+		}
+		else {
+			// failed to compress data
+			return false;
+		}
+
+		return true;
+	}
+
 	bool IsAlphaNumeric(const std::string &s) {
 		return std::all_of(s.begin(), s.end(), [](char c) -> bool { return isalnum(c); });
 	}

--- a/src/framework/utils.h
+++ b/src/framework/utils.h
@@ -151,6 +151,8 @@ namespace OpenWifi::Utils {
 	bool ExtractBase64CompressedData(const std::string &CompressedData,
 									 std::string &UnCompressedData, uint64_t compress_sz);
 
+	bool CompressAndEncodeBase64(const std::string& UnCompressedData, std::string& CompressedData);
+
 	inline bool match(const char* first, const char* second)
 	{
 		// If we reach at the end of both strings, we are done


### PR DESCRIPTION
# Description
When compression of configuration capability is reported by AP, configuration should be sent in compressed format.
Details are in: https://telecominfraproject.atlassian.net/browse/WIFI-14229

# Summary of changes:
- Modified code to compress configuration data, if capabilities object has compress command indicator enabled.
- Added encode and compress function to utilities.