### PR TITLE
fix: json parsing error

### DIFF
--- a/src/RESTAPI/RESTAPI_device_commandHandler.cpp
+++ b/src/RESTAPI/RESTAPI_device_commandHandler.cpp
@@ -711,7 +711,6 @@ namespace OpenWifi {
 							CompressedParams.set(uCentralProtocol::COMPRESS_64, CompressedBase64Data);
 							CompressedParams.set(uCentralProtocol::COMPRESS_SZ, UncompressedDataLen);
 							ConfigParams = CompressedParams;
-							Cmd.Details.append(" (compressed: " + CompressedBase64Data + ")");
 						}
 					}
 				}


### PR DESCRIPTION
# Description

Incorrect logging causes JSON parsing issues. More details:
https://telecominfraproject.atlassian.net/browse/WIFI-14292

# Summary of changes:
- Removed code that was incorrectly added to JSON string.

NOTE: This is cherry-pick PR.